### PR TITLE
Add the '\' back into instructions (seems to be actually necessary for rvm install to work on Linux)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,7 +8,7 @@ To get your Rails development environment setup, here's the steps to follow.  We
 
   1.  Install RVM
 
-      curl -L https://get.rvm.io | bash -s stable --ruby
+      \curl -L https://get.rvm.io | bash -s stable --ruby
 
   2.  Install the Ruby 1.9.3 rvm instance
 


### PR DESCRIPTION
...m.io/rvm/install
