### PR TITLE
Warning timeout2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'http://rubygems.org'
 gem 'rails', '3.2.14'
 gem 'mysql2'
-gem 'jquery-rails'
+gem 'auto-session-timeout'
+#gem 'jquery-rails'
+gem "jquery-rails", "~> 2.3.0"
 gem 'json', '~> 1.8.0'
 gem 'haml'
 gem 'devise'
@@ -31,6 +33,7 @@ gem 'capistrano-resque', '~> 0.1.0', :git => 'https://github.com/GSA-OCSIT/capis
 gem 'resque', :git => 'https://github.com/resque/resque.git', :branch => '1-x-stable', :require => 'resque/server'
 gem 'resque_mailer'
 gem 'devise-async'
+gem 'auto-session-timeout-warning'
 
 group :production do
   gem 'rack-openid', :git => 'https://github.com/GSA-OCSIT/rack-openid.git', :branch => 'pape'
@@ -58,7 +61,7 @@ group :test, :development do
   gem 'pry'
   gem 'pry-nav'
   gem 'rspec-rails'
-  gem "zeus-parallel_tests"
+  #gem "zeus-parallel_tests"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'http://rubygems.org'
 gem 'rails', '3.2.14'
 gem 'mysql2'
 gem 'auto-session-timeout'
-#gem 'jquery-rails'
 gem "jquery-rails", "~> 2.3.0"
 gem 'json', '~> 1.8.0'
 gem 'haml'
@@ -61,7 +60,6 @@ group :test, :development do
   gem 'pry'
   gem 'pry-nav'
   gem 'rspec-rails'
-  #gem "zeus-parallel_tests"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       builder
       json
     arel (3.0.2)
+    auto-session-timeout (0.9.2)
+    auto-session-timeout-warning (1.0.0)
     awesome_print (1.1.0)
     bcrypt-ruby (3.1.2)
     bigdecimal (1.2.1)
@@ -190,7 +192,7 @@ GEM
     httpauth (0.2.0)
     i18n (0.6.5)
     journey (1.0.4)
-    jquery-rails (3.0.4)
+    jquery-rails (2.3.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.0)
@@ -399,17 +401,14 @@ GEM
     will_paginate (3.0.4)
     xpath (0.1.4)
       nokogiri (~> 1.3)
-    zeus (0.13.3)
-      method_source (>= 0.6.7)
-    zeus-parallel_tests (0.2.4)
-      parallel_tests (>= 0.11.3)
-      zeus (~> 0.13.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   airbrake
+  auto-session-timeout
+  auto-session-timeout-warning
   awesome_print
   bigdecimal
   brakeman
@@ -430,7 +429,7 @@ DEPENDENCIES
   haml-rails
   hpricot
   httparty
-  jquery-rails
+  jquery-rails (~> 2.3.0)
   json (~> 1.8.0)
   launchy
   letter_opener
@@ -470,4 +469,3 @@ DEPENDENCIES
   validates_email_format_of!
   webmock
   will_paginate (~> 3.0)
-  zeus-parallel_tests

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,6 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 //= require jquery
+//= require jquery-ui
 //= require jquery_ujs
 //= require_tree .

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,13 @@
 class ApplicationController < ActionController::Base
   ensure_security_headers
+  before_timedout_action
   skip_before_filter :set_csp_header
   protect_from_forgery
   prepend_before_filter :set_no_keep_alive
   after_filter :set_response_headers, :cors_set_access_control_headers
   before_filter :set_segment, :set_session_will_expire, :cors_preflight_check
 
+  auto_session_timeout User.timeout_in.seconds
 
   def after_sign_out_path_for(resource_or_scope)
     sign_in_path

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,3 +1,10 @@
 class Users::SessionsController < Devise::SessionsController
-  
+  auto_session_timeout_actions
+  def active
+   render_session_status
+  end
+
+  def timeout
+    render_session_timeout
+  end  
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,7 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def timeout
-    render_session_timeout
+    flash[:notice] = "Your session has timed out."
+    redirect_to "/sign_in?timeout=true"
   end  
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,17 +75,15 @@ module ApplicationHelper
 
   
   def session_timeout_message
-    #if @session_to_expire_soon
-      here = link_to(t('remain_logged_in'), url_for(params.reject{ |k,v| k == "no_keep_alive" }))
-      content_tag :div, :id => 'inactivity_warning', :style=>"display:inline;", :class => "row" do
-        content_tag :div, :class => "twelve columns" do
-          content_tag :div, :class => "alert-box blue" do
-            content_tag('div', t('custom_session_timeout', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
-            link_to("&times;".html_safe, nil, class: 'close')
-          end.html_safe
-        end
+    here = link_to(t('remain_logged_in'), url_for(params.reject{ |k,v| k == "no_keep_alive" }))
+    content_tag :div, :id => 'inactivity_warning', :style=>"display:inline;", :class => "row" do
+      content_tag :div, :class => "twelve columns" do
+        content_tag :div, :class => "alert-box blue" do
+          content_tag('div', t('custom_session_timeout', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
+          link_to("&times;".html_safe, nil, class: 'close')
+        end.html_safe
       end
-    #end
+    end
   end
   def suffix_options
     ["Jr.","Sr.","II","III","IV"]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,19 +41,19 @@ module ApplicationHelper
 
   def refresh_meta_tag_conent
     if @session_to_expire_soon
-      tag('meta', :'http-equiv' => "refresh", :content => @wait_until_refresh) # If go to url and then go to login, doesn't have no_keep_alive.
+      tag('meta', :'http-equiv' => "refresh", :content => @wait_until_refresh, :id => 'meta-refresh') # If go to url and then go to login, doesn't have no_keep_alive.
     else
-      tag('meta', :'http-equiv' => "refresh", :content => "#{@wait_until_refresh};#{url_for(params.merge(no_keep_alive: 1))}")
+      tag('meta', :'http-equiv' => "refresh", :content => "#{@wait_until_refresh};#{url_for(params.merge(no_keep_alive: 1))}", :id => 'meta-refresh')
     end
   end
 
-  def session_timeout_message
+  def session_about_to_timeout_message_no_script
     if @session_to_expire_soon
       here = link_to(t('remain_logged_in'), url_for(params.reject{ |k,v| k == "no_keep_alive" }))
-      content_tag :div, :class => "row" do
+      content_tag :div, :id => 'inactivity_warning', :style=>"display:inline;", :class => "row" do
         content_tag :div, :class => "twelve columns" do
           content_tag :div, :class => "alert-box blue" do
-            content_tag('div', t('session_expiration_warning', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
+            content_tag('div', t('session_expiration_warning_no_script', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
             link_to("&times;".html_safe, nil, class: 'close')
           end.html_safe
         end
@@ -61,6 +61,32 @@ module ApplicationHelper
     end
   end
 
+  def session_about_to_timeout_message
+    here = link_to(t('remain_logged_in'), url_for(params.reject{ |k,v| k == "no_keep_alive" }))
+    content_tag :div, :id => 'inactivity_warning', :style=>"display:none;", :class => "row" do
+      content_tag :div, :class => "twelve columns" do
+        content_tag :div, :class => "alert-box blue" do
+          content_tag('div', t('session_expiration_warning', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
+          link_to("&times;".html_safe, nil, class: 'close')
+        end.html_safe
+      end
+    end
+  end
+
+  
+  def session_timeout_message
+    #if @session_to_expire_soon
+      here = link_to(t('remain_logged_in'), url_for(params.reject{ |k,v| k == "no_keep_alive" }))
+      content_tag :div, :id => 'inactivity_warning', :style=>"display:inline;", :class => "row" do
+        content_tag :div, :class => "twelve columns" do
+          content_tag :div, :class => "alert-box blue" do
+            content_tag('div', t('custom_session_timeout', link: here.html_safe, time: pluralize(Rails.application.config.session_timeout_warning_seconds, 'second')).html_safe) + "\n" +
+            link_to("&times;".html_safe, nil, class: 'close')
+          end.html_safe
+        end
+      end
+    #end
+  end
   def suffix_options
     ["Jr.","Sr.","II","III","IV"]
   end

--- a/app/helpers/auto_session_timeout_warning_helper.rb
+++ b/app/helpers/auto_session_timeout_warning_helper.rb
@@ -1,0 +1,71 @@
+module AutoSessionTimeoutWarningHelper
+  def auto_session_timeout_js(options={})
+    frequency = options[:frequency] || 60
+    timeout = options[:timeout] || 60
+    start = options[:start] || 60
+    warning = options[:warning] || 20
+    code = <<JS
+if(typeof(jQuery) != 'undefined'){
+  $("#logout_dialog").dialog({
+    modal: true,
+    bgiframe: true,
+    width: 500,
+    height: 180,
+    autoOpen: false,
+    dialogClass: "no-close"
+  });
+
+  $(".logout_dialog").click(function (e) {
+    e.preventDefault();
+
+    $("#logout_dialog").dialog('option', 'buttons', {
+      "Continue": function () {
+        window.location.reload();
+      }
+    });
+
+    $("#logout_dialog").dialog("open");
+
+  });
+
+  function PeriodicalQuery() {
+    $.ajax({
+      url: '/active',
+      success: function(data) {
+        if(new Date(data.timeout).getTime() < (new Date().getTime() + #{warning} * 1000)){
+          showDialog();
+        }else{
+          hideDialog();
+        }
+        if(data.live == false){
+          window.location.href = '/timeout';
+        }
+      }
+    });
+    setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+  }
+  setTimeout(PeriodicalQuery, (#{start} * 1000));
+
+  function showDialog(){
+    $('#inactivity_warning').attr('style', 'display:inline;')
+    $('.logout_dialog').trigger('click');
+  }
+  
+  function hideDialog(){
+    $('#inactivity_warning').attr('style', 'display:none;')
+  }  
+}
+JS
+    javascript_tag(code)
+  end
+
+  def auto_session_warning_tag(options={})
+    "<div id='logout_dialog' title='Logout Message' style='display:none;'>
+      You are about to be logged out of this system.
+      <br/><br/>
+      Please click Continue if you want to stay logged in.
+      </div> <div class='logout_dialog'></div>".html_safe
+  end
+end
+
+ActionView::Base.send :include, AutoSessionTimeoutWarningHelper

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,8 @@
   %head(prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# website: http://ogp.me/ns/website#")
     = yield :head
     - if current_user && request.get? # If it's a post, then no redirect
-      = refresh_meta_tag_conent    
+      %noscript
+        = refresh_meta_tag_conent
 
     = head_metadata(content_for?(:title) ? yield(:title) : "MyUSA", content_for?(:meta_description) ? yield(:meta_description) : "A platform for connecting people and government")
     
@@ -48,7 +49,11 @@
           .row
             .twelve.columns
         .container.group
-          = session_timeout_message
+          %noscript
+            = session_about_to_timeout_message_no_script
+          = session_about_to_timeout_message
+          - if params[:timeout].present?
+            = session_timeout_message
           = yield
         - unless current_user
           .no-toolbar
@@ -74,6 +79,15 @@
         \==================================================
       / Placed at the end of the document so the pages load faster
       = javascript_include_tag "application"
+      :javascript
+
+          if ($('#meta-refresh').length > 0) {
+            var mr = document.getElementById("meta-refresh");
+            console.log(mr);
+            mr.parentNode.removeChild(mr);
+          }
       = content_for :scripts
       = render :partial => "shared/ab", :locals => { :segment => @segment }
       = analytics_init if Rails.env.production?
+      - if current_user
+        = auto_session_timeout_js timeout:  User.timeout_in, frequency: Rails.application.config.session_check_frequency, start: 1, warning: Rails.application.config.session_timeout_warning_seconds

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,8 @@ module Mygov
     
     # Set the number of seconds the timeout warning should occur before login session is timed out
     config.session_timeout_warning_seconds = 20
+    config.session_timeout_in_seconds      = 1800
+    config.session_check_frequency         = 60
     
     config.to_prepare do
       Devise::Mailer.layout "notification_mailer"

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,7 +70,7 @@ module Mygov
     config.exceptions_app = self.routes
     
     # Set the number of seconds the timeout warning should occur before login session is timed out
-    config.session_timeout_warning_seconds = 20
+    config.session_timeout_warning_seconds = 90
     config.session_timeout_in_seconds      = 1800
     config.session_check_frequency         = 60
     

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,11 @@ Mygov::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
   
+  Devise.setup { |config| config.timeout_in = 10 }
+  config.session_timeout_warning_seconds = 7#20#5
+  config.session_timeout_in_seconds      = 10 #20#1800#20
+  config.session_check_frequency         = 3#60#2
+  
   # Turn on/off asset logging in rails server; it defaults to off, so turn it on here.
   # config.quiet_assets = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,10 +39,9 @@ Mygov::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
   
-  Devise.setup { |config| config.timeout_in = 10 }
-  config.session_timeout_warning_seconds = 7#20#5
-  config.session_timeout_in_seconds      = 10 #20#1800#20
-  config.session_check_frequency         = 3#60#2
+  Devise.setup { |config| config.timeout_in = 1800 }
+  config.session_timeout_warning_seconds    = 90
+  config.session_check_frequency            = 60
   
   # Turn on/off asset logging in rails server; it defaults to off, so turn it on here.
   # config.quiet_assets = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,10 +7,12 @@ en:
   sign_in_prompt: "Already using MyUSA?"
   sign_in_link: "Sign in"
   remain_logged_in: "Remain signed in."
+  session_expiration_warning_no_script: "We noticed you have not been very active in MyUSA. %{link}"
   session_expiration_warning: "We noticed you haven't been very active in MyUSA. %{link}"
   mygov_greeting: ""
   beta_signup_error: "An error occurred during signup.  Please try again."
   apps_leaving: "In a few seconds, you will be redirected to"
+  custom_session_timeout: 'Your session expired. Please sign in again.'
   
   errors:
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Mygov::Application.routes.draw do
     get 'thank_you', :to => 'users/registrations#thank_you', :as => :thank_you
     get 'sign_in', :to => 'users/sessions#new', :as => :sign_in
     get 'sign_out', :to => 'users/sessions#destroy', :as => :sign_out
+    get 'active'  => 'users/sessions#active',  via: :get
+    get 'timeout' => 'users/sessions#timeout', via: :get
   end
   get 'oauth/authorize' => 'oauth#authorize'
   post 'oauth/authorize' => 'oauth#authorize'

--- a/spec/requests/inactivity_logout_spec.rb
+++ b/spec/requests/inactivity_logout_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "auto_logout" do
   context "User is logged in" do
     before do
-      @inactivity_warning_text = "We noticed you haven't been very active in MyUSA"
+      @inactivity_warning_text = "We noticed you have not been very active in MyUSA"
       Devise.setup { |config| config.timeout_in = 4 }
       Rails.application.config.session_timeout_warning_seconds = 2
 


### PR DESCRIPTION
This is a inactivity warning timeout solution for javascript enabled browsers. It uses https://github.com/krishnasrihari/auto-session-timeout-warning.  Javascript disabled browsers still use the no_keep_alive version.

To see it in action, edit these lines in development.rb
  Devise.setup { |config| config.timeout_in        = 1800 }
  config.session_timeout_warning_seconds    = 90
  config.session_check_frequency                     = 60
