### PR TITLE
FIX: Profile API does not return error if user does not have profile scope authorized

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,24 +13,21 @@ class Api::ApiController < ApplicationController
     end
   end
   
-  def no_scope_message
-    "You do not have permission to read that user's profile."
-  end
-  
-  def validate_oauth(oauth_scope = nil)
+  def validate_oauth(oauth_scopes)
     unless @token.valid?
       render :json => {:message => "Invalid token"}, :status => @token.response_status
       return false
     end
 
-    return true unless oauth_scope
-    
     auth = @token.authorization
     scope_list = auth && auth.scope
-    unless scope_in_scope_list?(oauth_scope, scope_list)
-      render :json => {:message => no_scope_message}, :status => 403
-      return false
+    
+    oauth_scopes.each do |oauth_scope|
+      return true if scope_in_scope_list?(oauth_scope, scope_list)
     end
+    
+    render :json => {:message => no_scope_message}, :status => 403
+    return false
   end
   
   def scope_in_scope_list?(oauth_scope, scope_list)

--- a/app/controllers/api/v1/credentials_controller.rb
+++ b/app/controllers/api/v1/credentials_controller.rb
@@ -28,6 +28,6 @@ class Api::V1::CredentialsController < Api::ApiController
   end
   
   def oauthorize_scope
-    validate_oauth(OauthScope.find_by_scope_name('verify_credentials'))
+    validate_oauth(OauthScope.find_all_by_scope_name('verify_credentials'))
   end
 end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -20,6 +20,6 @@ class Api::V1::NotificationsController < Api::ApiController
   end
   
   def oauthorize_scope
-    validate_oauth(OauthScope.find_by_scope_name('notifications'))
+    validate_oauth(OauthScope.find_all_by_scope_name('notifications'))
   end
 end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ProfilesController < Api::ApiController
-  before_filter :validate_oauth
+  before_filter :oauthorize_scope
   
   def show
     scope_list = @token.authorization.scope.split(" ")
@@ -10,5 +10,15 @@ class Api::V1::ProfilesController < Api::ApiController
       # Limit profile attributes to just those chosen by app owner during app registration.
       render :json => filtered_profile.as_json(:scope_list => scope_list).merge("uid" => @user.uid, "id" => @user.uid)
     end
+  end
+  
+  protected
+  
+  def no_scope_message
+    "You do not have permission to read that user's profile."
+  end
+  
+  def oauthorize_scope
+    validate_oauth(OauthScope.profile_scopes)
   end
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -28,6 +28,6 @@ class Api::V1::TasksController < Api::ApiController
   end
   
   def oauthorize_scope
-    validate_oauth(OauthScope.find_by_scope_name('tasks'))
+    validate_oauth(OauthScope.find_all_by_scope_name('tasks'))
   end
 end

--- a/app/models/oauth_scope.rb
+++ b/app/models/oauth_scope.rb
@@ -5,6 +5,7 @@ class OauthScope < ActiveRecord::Base
   attr_accessible :description, :name, :scope_name, :scope_type, :as => [:default, :admin]
   
   scope :top_level_scopes, -> { where("scope_name NOT LIKE :dot", :dot => "%.%") }
+  scope :profile_scopes, -> {where("scope_name LIKE :profile_pattern", :profile_pattern => "profile%")}
   
   def is_parent?
     OauthScope.all.any?{|s| s.scope_name.match(/#{self.name}\./i)}


### PR DESCRIPTION
If no profile scopes are authorized, the app will still allow a caller to get access to the profile.  Instead, it should respond with an error and 403 status.
