### PR TITLE
Checkbox text fix

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1456,6 +1456,8 @@ span[aria-hidden="false"] {display:block;}
   color: #fff;
 }
 
+label div.field_with_errors a{color: #fff; text-decoration: underline}  // Customization for checkbox label with errors
+label div.field_with_errors a:hover{color: #fff;}  // Customization for checkbox label with errors
 label div.field_with_errors {color: #fff; text-shadow: none; margin: 0; padding: .2em; }  // Customization for checkbox label with errors
 .field_with_errors { background: #961D19; }
 .field_with_errors label {color: #fff; text-shadow: none; margin: 0; padding: .2em; }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1456,6 +1456,7 @@ span[aria-hidden="false"] {display:block;}
   color: #fff;
 }
 
+label div.field_with_errors {color: #fff; text-shadow: none; margin: 0; padding: .2em; }  // Customization for checkbox label with errors
 .field_with_errors { background: #961D19; }
 .field_with_errors label {color: #fff; text-shadow: none; margin: 0; padding: .2em; }
 .field_with_errors input[type="text"],

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -46,9 +46,9 @@
                   %i (Not required)
                 = f.text_field :zip, {'aria-described-by'=>'tip-zip'}
               %li
-                = f.label :terms_of_service do
-                  = f.check_box :terms_of_service
-                  = t(:i_agree_html, :terms_of_service_link => link_to(t(:terms_of_service), terms_of_service_path), :privacy_policy_link => link_to(t(:privacy_policy), privacy_policy_path))
+                = f.label :terms_of_service do 
+                  = f.check_box :terms_of_service, {}, "1", "0", t(:i_agree_html, :terms_of_service_link => link_to(t(:terms_of_service), terms_of_service_path), :privacy_policy_link => link_to(t(:privacy_policy), privacy_policy_path))
+                  
               %li
                 = recaptcha_tags display: {theme: 'clean'} if recaptcha_needed?
               %li= f.submit t(:sign_up), :class => 'button positive', :accesskey => access_keys[:submit]

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -68,9 +68,9 @@ module ActionView
         InstanceTag.new(object_name, method, self, options.delete(:object)).to_text_area_tag(options)
       end
 
-      def check_box(object_name, method, options = {}, checked_value = "1", unchecked_value = "0")
+      def check_box(object_name, method, options = {}, checked_value = "1", unchecked_value = "0", checkbox_text = nil)
       	options.merge!({'aria-required' => true}) if options[:object].class.validators_on(method).map(&:class).include? ActiveModel::Validations::PresenceValidator
-        InstanceTag.new(object_name, method, self, options.delete(:object)).to_check_box_tag(options, checked_value, unchecked_value)
+        InstanceTag.new(object_name, method, self, options.delete(:object)).to_check_box_tag(options, checked_value, unchecked_value, checkbox_text)
       end
 
       def radio_button(object_name, method, tag_value, options = {})

--- a/spec/requests/authentications_spec.rb
+++ b/spec/requests/authentications_spec.rb
@@ -139,6 +139,7 @@ describe "Authentications" do
         # Click sign up before checking TOS
         click_button 'Sign up'
         page.should have_content "Terms of service must be accepted"
+        page.should have_xpath("//label[@for='user_terms_of_service']//div[@class='field_with_errors']//a[@href='/terms-of-service']")
         page.should_not have_content "Password"
         # User is returned to sign up page
         check('user_terms_of_service')


### PR DESCRIPTION
#68074112 "Check box fields that have errors are incorrectly styled"

Overrode checkbox template by adding "checkbox_text" argument. Overrode Error wrapping styling for checkbox and label. About to send pull request.

Screen shots are available at https://www.pivotaltracker.com/s/projects/612575/stories/68074112
